### PR TITLE
updated README to include full package path

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ The following code
 package hamcrest_test
 
 import (
-    . "hamcrest"
     "testing"
+
+    . "github.com/pepinns/go-hamcrest"
 )
 
 func TestStringEqualsFailsWithAsserter(t *testing.T) {
@@ -49,8 +50,9 @@ The following Code
 
 ``` go
 import (
-    . "hamcrest"
     "testing"
+
+    . "github.com/pepinns/go-hamcrest"
 )
 
 type TestObject struct {


### PR DESCRIPTION
This change allows a user to easily copy and paste the examples and run them without having to go back and look up the fully qualified package name